### PR TITLE
Fix incorrect anchor and remove duplicate #example IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 
 # dependencies
 node_modules/

--- a/src/pattern-library/components/cards/product-card.html
+++ b/src/pattern-library/components/cards/product-card.html
@@ -41,7 +41,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/components/forms/search.html
+++ b/src/pattern-library/components/forms/search.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/components/navigation/signpost.html
+++ b/src/pattern-library/components/navigation/signpost.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/components/navigation/skip-navigation.html
+++ b/src/pattern-library/components/navigation/skip-navigation.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/components/navigation/tags.html
+++ b/src/pattern-library/components/navigation/tags.html
@@ -41,7 +41,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/bullet-list.html
+++ b/src/pattern-library/foundations/bullet-list.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/buttons.html
+++ b/src/pattern-library/foundations/buttons.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/centring.html
+++ b/src/pattern-library/foundations/centring.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/checkboxes-and-radio-buttons.html
+++ b/src/pattern-library/foundations/checkboxes-and-radio-buttons.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/collapsing-columns.html
+++ b/src/pattern-library/foundations/collapsing-columns.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/colour.html
+++ b/src/pattern-library/foundations/colour.html
@@ -39,7 +39,7 @@ id: pattern-library
         <div class="coop-l-row">
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
-                    <section id="example" class="coop-u-margin-bb">
+                    <section class="coop-u-margin-bb">
                         <style>
                             .dm-colour__swatch.coop-u-grey-light-bg {
                                 border: 1px solid #c4c4c4;

--- a/src/pattern-library/foundations/font.html
+++ b/src/pattern-library/foundations/font.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/input.html
+++ b/src/pattern-library/foundations/input.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/links.html
+++ b/src/pattern-library/foundations/links.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/logo.html
+++ b/src/pattern-library/foundations/logo.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/numbered-list.html
+++ b/src/pattern-library/foundations/numbered-list.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/offset-columns.html
+++ b/src/pattern-library/foundations/offset-columns.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/page-layout.html
+++ b/src/pattern-library/foundations/page-layout.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/quotations.html
+++ b/src/pattern-library/foundations/quotations.html
@@ -41,7 +41,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
@@ -81,7 +81,7 @@ id: pattern-library
                 <h2>Accessibility</h2>
                 <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
             </section>
-            <section id="accessibility" class="m-tb-med-x margin-bb padding-bh">
+            <section id="variations" class="m-tb-med-x margin-bb padding-bh">
                 <h2>Variations</h2>
                 <p>{{ designPattern.variations | markdownify }}</p>
             </section>

--- a/src/pattern-library/foundations/reorder-columns.html
+++ b/src/pattern-library/foundations/reorder-columns.html
@@ -40,7 +40,7 @@ id: pattern-library
             <div class="coop-l-column coop-l-all-12">
                 <section id="example" class="coop-ds-example">
                     <header class="ds-pen-example__header">
-                        <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
                     </header>
                     <div id="TabContainer">
                         <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/responsive-tables.html
+++ b/src/pattern-library/foundations/responsive-tables.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/submit.html
+++ b/src/pattern-library/foundations/submit.html
@@ -41,7 +41,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/tables.html
+++ b/src/pattern-library/foundations/tables.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/textarea.html
+++ b/src/pattern-library/foundations/textarea.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/typographic-scale.html
+++ b/src/pattern-library/foundations/typographic-scale.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">

--- a/src/pattern-library/foundations/validation.html
+++ b/src/pattern-library/foundations/validation.html
@@ -40,7 +40,7 @@ id: pattern-library
                 <div class="coop-l-column coop-l-all-12">
                     <section id="example" class="coop-ds-example">
                         <header class="ds-pen-example__header">
-                            <h2 id="example" class="Pen-panel-title pull-left">Example</h2>
+                            <h2 class="Pen-panel-title pull-left">Example</h2>
                         </header>
                         <div id="TabContainer">
                             <div class="accordion-wrapper">


### PR DESCRIPTION
- Fix anchor to `#variations` on Quotations page (was pointing to `#accessibility`)
- Remove duplicate `#example` ids