### PR TITLE
Ignore JetBrains editors cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ build/
 
 # nmp linux stuff
 npm-debug.log
+
+# Editor caches
+.idea/


### PR DESCRIPTION
A quick one to add `.idea` directories to `.gitignore` for people using JetBrains editors (WebStorm, IntelliJ, etc).